### PR TITLE
Add a comment to each packet containing the process id (PID)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ msbuild -t:rebuild -p:configuration=release -p:platform=x64
 
 # History
 
-1.2.0 + PID comment - Add a comment to each packet containing the process id (PID).
+1.3.0 - Add a comment to each packet containing the process id (PID).
 
 1.2.0 - Write direction info of each packet (epb_flags)
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ msbuild -t:rebuild -p:configuration=release -p:platform=x64
 
 # History
 
+1.2.0 + PID comment - Add a comment to each packet containing the process id (PID).
+
 1.2.0 - Write direction info of each packet (epb_flags)
 
 1.1.0 - Added support for multi-event packets found in traces from Win8 and older

--- a/src/main.c
+++ b/src/main.c
@@ -24,6 +24,7 @@ Issues:
 #include <evntrace.h>
 #include <evntcons.h>
 #include <tdh.h>
+#include <strsafe.h>
 #include <pcapng.h>
 
 #define USAGE \
@@ -285,7 +286,8 @@ void WINAPI EventCallback(PEVENT_RECORD ev)
             Iface->PcapNgIfIndex,
             !!(ev->EventHeader.EventDescriptor.Keyword & KW_SEND),
             TimeStamp.HighPart,
-            TimeStamp.LowPart);
+            TimeStamp.LowPart,
+            ev->EventHeader.ProcessId);
         AuxFragBufOffset = 0;
         NumFramesConverted++;
     } else {

--- a/src/pcapng.h
+++ b/src/pcapng.h
@@ -183,9 +183,9 @@ PcapNgWriteEnhancedPacket(
             CommentLength = 0;
         }
     }
-	else {
+    else {
         memset(Comment, 0, COMMENT_MAX_SIZE);
-	}
+    }
     CommentOption.Code = PCAPNG_OPTIONCODE_COMMENT;
     CommentOption.Length = (unsigned short) CommentLength;
     if (CommentOption.Length % 4 != 0)

--- a/src/pcapng.h
+++ b/src/pcapng.h
@@ -173,19 +173,22 @@ PcapNgWriteEnhancedPacket(
 // COMMENT_MAX_SIZE must be multiple of 4
 #define COMMENT_MAX_SIZE 16
     char Comment[COMMENT_MAX_SIZE] = { 0 };
+    size_t CommentLength = 0;
     int FragPadLength = (4 - ((sizeof(Body) + FragLength) & 3)) & 3; // pad to 4 bytes per the spec.
     int TotalLength =
         sizeof(Head) + sizeof(Body) + FragLength + FragPadLength +
         sizeof(EpbFlagsOption) + sizeof(CommentOption) + sizeof(EndOption) + sizeof(Tail);
 
     memset(Comment, 0, COMMENT_MAX_SIZE);
-    if FAILED(StringCchPrintfA(Comment, COMMENT_MAX_SIZE, "PID=%d", ProcessID))
+    if SUCCEEDED(StringCchPrintfA(Comment, COMMENT_MAX_SIZE, "PID=%d", ProcessID)) {
+        if FAILED(StringCchLengthA(Comment, COMMENT_MAX_SIZE, &CommentLength))
+            CommentLength = 0;
+    }
+    else
         memset(Comment, 0, COMMENT_MAX_SIZE);
     CommentOption.Code = PCAPNG_OPTIONCODE_COMMENT;
-    CommentOption.Length = (unsigned short)strlen(Comment);
-    if (CommentOption.Length > COMMENT_MAX_SIZE)
-        CommentOption.Length = COMMENT_MAX_SIZE;
-    else if (CommentOption.Length % 4 != 0)
+    CommentOption.Length = (unsigned short) CommentLength;
+    if (CommentOption.Length % 4 != 0)
         CommentOption.Length += (4 - CommentOption.Length % 4);
     TotalLength += CommentOption.Length;
 

--- a/src/pcapng.h
+++ b/src/pcapng.h
@@ -59,8 +59,8 @@ struct PCAPNG_BLOCK_OPTION_EPB_FLAGS {
     long Value;
 };
 struct PCAPNG_BLOCK_OPTION_COMMENT {
-    short Code; // PCAPNG_OPTIONCODE_COMMENT
-    short Length;
+    unsigned short Code; // PCAPNG_OPTIONCODE_COMMENT
+    unsigned short Length;
 };
 struct PCAPNG_BLOCK_TAIL {
     long Length; // Same as PCAPNG_BLOCK_HEAD.Length, for easier backward processing.
@@ -182,7 +182,7 @@ PcapNgWriteEnhancedPacket(
     if FAILED(StringCchPrintfA(Comment, COMMENT_MAX_SIZE, "PID=%d", ProcessID))
         memset(Comment, 0, COMMENT_MAX_SIZE);
     CommentOption.Code = PCAPNG_OPTIONCODE_COMMENT;
-    CommentOption.Length = (short)strlen(Comment);
+    CommentOption.Length = (unsigned short)strlen(Comment);
     if (CommentOption.Length > COMMENT_MAX_SIZE)
         CommentOption.Length = COMMENT_MAX_SIZE;
     else if (CommentOption.Length % 4 != 0)


### PR DESCRIPTION
Added code to add a comment with the process id (PID) to each packet.

https://twitter.com/DidierStevens/status/1211035501920210946

Maybe introduce a command-line option for this.