### PR TITLE
Adding support for NDIS Metadata blocks as comments in pcapng

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -228,7 +228,7 @@ CombineMetadataWithPacket(
     _In_ long TimeStampLow,
     _In_ PDOT11_EXTSTA_RECV_CONTEXT Metadata,
     _In_ unsigned long ProcessId
-)
+    )
 {
 
     char Comment[MAX_PACKET_SIZE] = { 0 };

--- a/src/main.c
+++ b/src/main.c
@@ -62,7 +62,7 @@ typedef struct DOT11_EXTSTA_RECV_CONTEXT {
     long               lRSSI;
     unsigned char      ucDataRate;
     unsigned long      uSizeMediaSpecificInfo;
-    void* pvMediaSpecificInfo;
+    void               *pvMediaSpecificInfo;
     unsigned long long ullTimestamp;
 } DOT11_EXTSTA_RECV_CONTEXT, * PDOT11_EXTSTA_RECV_CONTEXT;
 #pragma pack(pop)
@@ -281,8 +281,8 @@ void WINAPI EventCallback(PEVENT_RECORD ev)
 
     if (!IsEqualGUID(&ev->EventHeader.ProviderId, &NdisCapId) ||
         (ev->EventHeader.EventDescriptor.Id != tidPacketFragment &&
-            ev->EventHeader.EventDescriptor.Id != tidPacketMetadata &&
-            ev->EventHeader.EventDescriptor.Id != tidVMSwitchPacketFragment)) {
+         ev->EventHeader.EventDescriptor.Id != tidPacketMetadata &&
+         ev->EventHeader.EventDescriptor.Id != tidVMSwitchPacketFragment)) {
         return;
     }
 
@@ -474,7 +474,7 @@ int __cdecl wmain(int argc, wchar_t** argv)
 
     if (argc == 2 &&
         (!wcscmp(argv[1], L"-v") ||
-            !wcscmp(argv[1], L"--version"))) {
+         !wcscmp(argv[1], L"--version"))) {
         printf("etl2pcapng version 1.4.0\n");
         return 0;
     }
@@ -487,7 +487,7 @@ int __cdecl wmain(int argc, wchar_t** argv)
     OutFileName = argv[2];
 
     OutFile = CreateFile(OutFileName, GENERIC_WRITE, 0, NULL, CREATE_ALWAYS,
-        FILE_ATTRIBUTE_NORMAL, NULL);
+                         FILE_ATTRIBUTE_NORMAL, NULL);
     if (OutFile == INVALID_HANDLE_VALUE) {
         Err = GetLastError();
         printf("CreateFile called on %ws failed with %u\n", OutFileName, Err);

--- a/src/main.c
+++ b/src/main.c
@@ -41,11 +41,55 @@ Issues:
 #define KW_SEND                 0x100000000
 #define KW_RECEIVE              0x200000000
 
+#define tidPacketFragment            1001
+#define tidPacketMetadata            1002
+#define tidVMSwitchPacketFragment    1003
+
+// From: https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/windot11/ns-windot11-dot11_extsta_recv_context
+#pragma pack(push,8)
+typedef struct _NDIS_OBJECT_HEADER {
+    UCHAR  Type;
+    UCHAR  Revision;
+    USHORT Size;
+} NDIS_OBJECT_HEADER, * PNDIS_OBJECT_HEADER;
+
+typedef struct DOT11_EXTSTA_RECV_CONTEXT {
+    NDIS_OBJECT_HEADER Header;
+    ULONG              uReceiveFlags;
+    ULONG              uPhyId;
+    ULONG              uChCenterFrequency;
+    USHORT             usNumberOfMPDUsReceived;
+    LONG               lRSSI;
+    UCHAR              ucDataRate;
+    ULONG              uSizeMediaSpecificInfo;
+    PVOID              pvMediaSpecificInfo;
+    ULONGLONG          ullTimestamp;
+} DOT11_EXTSTA_RECV_CONTEXT, * PDOT11_EXTSTA_RECV_CONTEXT;
+#pragma pack(pop)
+
+// From: https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/windot11/ne-windot11-_dot11_phy_type
+static const char* DOT11_PHY_TYPE_NAMES[] = {
+    "Unknown",        // dot11_phy_type_unknown = 0
+    "Fhss",           // dot11_phy_type_fhss = 1
+    "Dsss",           // dot11_phy_type_dsss = 2
+    "IrBaseband",     // dot11_phy_type_irbaseband = 3
+    "802.11a",        // dot11_phy_type_ofdm = 4
+    "802.11b",        // dot11_phy_type_hrdsss = 5
+    "802.11g",        // dot11_phy_type_erp = 6
+    "802.11n",        // dot11_phy_type_ht = 7
+    "802.11ac",       // dot11_phy_type_vht = 8
+    "802.11ad",       // dot11_phy_type_dmg = 9
+    "802.11ax"        // dot11_phy_type_he = 10
+};
+
 HANDLE OutFile = INVALID_HANDLE_VALUE;
 unsigned long long NumFramesConverted = 0;
 BOOLEAN Pass2 = FALSE;
 char AuxFragBuf[MAX_PACKET_SIZE] = {0};
 unsigned long AuxFragBufOffset = 0;
+
+DOT11_EXTSTA_RECV_CONTEXT PacketMetadata;
+BOOLEAN AddMetadata = FALSE;
 
 const GUID NdisCapId = { // Microsoft-Windows-NDIS-PacketCapture {2ED6006E-4729-4609-B423-3EE7BCD678EF}
     0x2ed6006e, 0x4729, 0x4609, 0xb4, 0x23, 0x3e, 0xe7, 0xbc, 0xd6, 0x78, 0xef};
@@ -173,6 +217,63 @@ void WriteInterfaces()
     free(InterfaceArray);
 }
 
+inline int
+CombineMetadataWithPacket(
+    _In_ HANDLE File,
+    _In_ PCHAR FragBuf,
+    _In_ unsigned long FragLength,
+    _In_ long InterfaceId,
+    _In_ long IsSend,
+    _In_ long TimeStampHigh, // usec (unless if_tsresol is used)
+    _In_ long TimeStampLow,
+    _In_ PDOT11_EXTSTA_RECV_CONTEXT Metadata,
+    _In_ unsigned long ProcessId
+)
+{
+
+    char Comment[MAX_PACKET_SIZE] = { 0 };
+    size_t commentlength = 0;
+
+    HRESULT Err = StringCchPrintfA((char*)&Comment, MAX_PACKET_SIZE, "Packet Metadata: ReceiveFlags:0x%x, PhyType:%s, CenterCh:%u, NumMPDUsReceived:%u, RSSI:%d, DataRate:%u, PID=%d",
+        Metadata->uReceiveFlags,
+        DOT11_PHY_TYPE_NAMES[Metadata->uPhyId],
+        Metadata->uChCenterFrequency,
+        Metadata->usNumberOfMPDUsReceived,
+        Metadata->lRSSI,
+        Metadata->ucDataRate,
+        ProcessId);
+
+    if (FAILED(Err))
+    {
+        printf("Failed converting NdisMetadata to string with error: %u\n", Err);
+    }
+    else
+    {
+        Err = StringCchLengthA((char*)&Comment, MAX_PACKET_SIZE, &commentlength);
+
+        if (FAILED(Err))
+        {
+            printf("Failed getting length of metadata string with error: %u\n", Err);
+            commentlength = 0;
+            memset(&Comment, 0, MAX_PACKET_SIZE);
+        }
+    }
+
+
+
+
+    return PcapNgWriteEnhancedPacket(
+        File,
+        FragBuf,
+        sizeof(DOT11_EXTSTA_RECV_CONTEXT) + FragLength,
+        InterfaceId,
+        IsSend,
+        TimeStampHigh,
+        TimeStampLow,
+        commentlength > 0 ? (char*)&Comment : NULL,
+        (USHORT)commentlength);
+}
+
 void WINAPI EventCallback(PEVENT_RECORD ev)
 {
     int Err;
@@ -183,8 +284,9 @@ void WINAPI EventCallback(PEVENT_RECORD ev)
     ULARGE_INTEGER TimeStamp;
 
     if (!IsEqualGUID(&ev->EventHeader.ProviderId, &NdisCapId) ||
-        (ev->EventHeader.EventDescriptor.Id != 1001 &&  // tidPacketFragment
-         ev->EventHeader.EventDescriptor.Id != 1003)) { // tidVMSwitchPacketFragment
+        (ev->EventHeader.EventDescriptor.Id != tidPacketFragment &&
+         ev->EventHeader.EventDescriptor.Id != tidPacketMetadata &&
+         ev->EventHeader.EventDescriptor.Id != tidVMSwitchPacketFragment)) {
         return;
     }
 
@@ -192,7 +294,7 @@ void WINAPI EventCallback(PEVENT_RECORD ev)
     Desc.ArrayIndex = ULONG_MAX;
     Err = TdhGetProperty(ev, 0, NULL, 1, &Desc, sizeof(LowerIfIndex), (PBYTE)&LowerIfIndex);
     if (Err != NO_ERROR) {
-        printf("TdhGetPropertySize failed with %u\n", Err);
+        printf("TdhGetProperty LowerIfIndex failed with %u\n", Err);
         return;
     }
 
@@ -214,7 +316,7 @@ void WINAPI EventCallback(PEVENT_RECORD ev)
             Desc.ArrayIndex = ULONG_MAX;
             Err = TdhGetProperty(ev, 0, NULL, 1, &Desc, sizeof(MiniportIfIndex), (PBYTE)&MiniportIfIndex);
             if (Err != NO_ERROR) {
-                printf("TdhGetPropertySize failed with %u\n", Err);
+                printf("TdhGetProperty MiniportIfIndex failed with %u\n", Err);
                 return;
             }
             AddInterface(LowerIfIndex, MiniportIfIndex, Type);
@@ -231,6 +333,36 @@ void WINAPI EventCallback(PEVENT_RECORD ev)
         exit(1);
     }
 
+    //Save off Ndis/Wlan metadata to be added to the next packet
+    if (ev->EventHeader.EventDescriptor.Id == tidPacketMetadata)
+    {
+        DWORD MetadataLength = 0;
+        Desc.PropertyName = (ULONGLONG)L"MetadataSize";
+        Desc.ArrayIndex = ULONG_MAX;
+        Err = TdhGetProperty(ev, 0, NULL, 1, &Desc, sizeof(MetadataLength), (PBYTE)&MetadataLength);
+        if (Err != NO_ERROR) {
+            printf("TdhGetProperty MetadataSize failed with %u\n", Err);
+            return;
+        }
+
+        if (MetadataLength != sizeof(PacketMetadata))
+        {
+            printf("Unknown Metadata length. Expected %u, got %u\n", sizeof(DOT11_EXTSTA_RECV_CONTEXT), MetadataLength);
+            return;
+        }
+
+        Desc.PropertyName = (ULONGLONG)L"Metadata";
+        Desc.ArrayIndex = ULONG_MAX;
+        Err = TdhGetProperty(ev, 0, NULL, 1, &Desc, MetadataLength, (PBYTE)&PacketMetadata);
+        if (Err != NO_ERROR) {
+            printf("TdhGetProperty Metadata failed with %u\n", Err);
+            return;
+        }
+
+        AddMetadata = TRUE;
+        return;
+    }
+
     // N.B.: Here we are querying the FragmentSize property to get the
     // total size of the packet, and then reading that many bytes from
     // the Fragment property. This is unorthodox (normally you are
@@ -243,7 +375,7 @@ void WINAPI EventCallback(PEVENT_RECORD ev)
     Desc.ArrayIndex = ULONG_MAX;
     Err = TdhGetProperty(ev, 0, NULL, 1, &Desc, sizeof(FragLength), (PBYTE)&FragLength);
     if (Err != NO_ERROR) {
-        printf("TdhGetPropertySize failed with %u\n", Err);
+        printf("TdhGetProperty FragmentSize failed with %u\n", Err);
         return;
     }
 
@@ -256,7 +388,7 @@ void WINAPI EventCallback(PEVENT_RECORD ev)
     Desc.ArrayIndex = ULONG_MAX;
     Err = TdhGetProperty(ev, 0, NULL, 1, &Desc, FragLength, (PBYTE)(AuxFragBuf + AuxFragBufOffset));
     if (Err != NO_ERROR) {
-        printf("TdhGetPropertySize failed with %u\n", Err);
+        printf("TdhGetProperty Fragment failed with %u\n", Err);
         return;
     }
 
@@ -279,15 +411,58 @@ void WINAPI EventCallback(PEVENT_RECORD ev)
     // This logic is here to support packet captures from older systems.
 
     if (!!(ev->EventHeader.EventDescriptor.Keyword & KW_PACKET_END)) {
-        PcapNgWriteEnhancedPacket(
-            OutFile,
-            AuxFragBuf,
-            AuxFragBufOffset + FragLength,
-            Iface->PcapNgIfIndex,
-            !!(ev->EventHeader.EventDescriptor.Keyword & KW_SEND),
-            TimeStamp.HighPart,
-            TimeStamp.LowPart,
-            ev->EventHeader.ProcessId);
+
+        if (ev->EventHeader.EventDescriptor.Keyword & KW_MEDIA_NATIVE_802_11 &&
+            AuxFragBuf[1] & 0x40)
+        {
+            // Clear Protected bit in the case of 802.11
+            // Ndis captures will be decrypted in the etl file
+
+            AuxFragBuf[1] = AuxFragBuf[1] & 0xBF; // _1011_1111_ - Clear "Protected Flag"
+        }
+
+        if (AddMetadata)
+        {
+            CombineMetadataWithPacket(
+                OutFile,
+                AuxFragBuf,
+                AuxFragBufOffset + FragLength,
+                Iface->PcapNgIfIndex,
+                !!(ev->EventHeader.EventDescriptor.Keyword & KW_SEND),
+                TimeStamp.HighPart,
+                TimeStamp.LowPart,
+                &PacketMetadata,
+                ev->EventHeader.ProcessId
+            );
+        }
+        else
+        {
+            // COMMENT_MAX_SIZE must be multiple of 4
+            #define COMMENT_MAX_SIZE 16
+            char Comment[COMMENT_MAX_SIZE] = { 0 };
+            size_t CommentLength = 0;
+
+            if SUCCEEDED(StringCchPrintfA(Comment, COMMENT_MAX_SIZE, "PID=%d", ev->EventHeader.ProcessId)) {
+                if FAILED(StringCchLengthA(Comment, COMMENT_MAX_SIZE, &CommentLength)) {
+                    CommentLength = 0;
+                }
+            }
+
+            PcapNgWriteEnhancedPacket(
+                OutFile,
+                AuxFragBuf,
+                AuxFragBufOffset + FragLength,
+                Iface->PcapNgIfIndex,
+                !!(ev->EventHeader.EventDescriptor.Keyword & KW_SEND),
+                TimeStamp.HighPart,
+                TimeStamp.LowPart,
+                CommentLength > 0 ? (char*)&Comment : NULL,
+                (USHORT)CommentLength);
+        }
+
+        AddMetadata = FALSE;
+        memset(&PacketMetadata, 0, sizeof(DOT11_EXTSTA_RECV_CONTEXT));
+
         AuxFragBufOffset = 0;
         NumFramesConverted++;
     } else {
@@ -306,7 +481,7 @@ int __cdecl wmain(int argc, wchar_t** argv)
     if (argc == 2 &&
         (!wcscmp(argv[1], L"-v") ||
          !wcscmp(argv[1], L"--version"))) {
-        printf("etl2pcapng version 1.3.0\n");
+        printf("etl2pcapng version 1.4.0\n");
         return 0;
     }
 

--- a/src/pcapng.h
+++ b/src/pcapng.h
@@ -209,12 +209,12 @@ PcapNgWriteEnhancedPacket(
     struct PCAPNG_BLOCK_OPTION_EPB_FLAGS EpbFlagsOption;
     struct PCAPNG_BLOCK_TAIL Tail;
     char Pad[4] = {0};
-    BOOLEAN commentprovided = (CommentLength > 0 && Comment != NULL);
+    BOOLEAN CommentProvided = (CommentLength > 0 && Comment != NULL);
     int FragPadLength = (4 - ((sizeof(Body) + FragLength) & 3)) & 3; // pad to 4 bytes per the spec.
     int TotalLength =
         sizeof(Head) + sizeof(Body) + FragLength + FragPadLength +
         sizeof(EpbFlagsOption) + sizeof(EndOption) + sizeof(Tail) +
-        (commentprovided ?
+        (CommentProvided ?
             sizeof(struct PCAPNG_BLOCK_OPTION_COMMENT) + sizeof(EndOption) + CommentLength +
             (4 - (CommentLength % 4 == 0 ? 4 : CommentLength % 4)) //Comment Padding
             : 0);
@@ -259,7 +259,7 @@ PcapNgWriteEnhancedPacket(
         goto Done;
     }
 
-    if (commentprovided) {
+    if (CommentProvided) {
         Err = PcapNgWriteCommentOption(
             File,
             Comment,

--- a/src/pcapng.h
+++ b/src/pcapng.h
@@ -71,7 +71,7 @@ struct PCAPNG_BLOCK_TAIL {
 inline int
 PcapNgWriteSectionHeader(
     HANDLE File
-)
+    )
 {
     int Err = NO_ERROR;
     struct PCAPNG_BLOCK_HEAD Head;
@@ -114,7 +114,7 @@ PcapNgWriteInterfaceDesc(
     HANDLE File,
     short LinkType,
     long SnapLen
-)
+    )
 {
     int Err = NO_ERROR;
     struct PCAPNG_BLOCK_HEAD Head;
@@ -156,7 +156,7 @@ PcapNgWriteCommentOption(
     __in HANDLE File,
     __in PCHAR CommentBuffer,
     __in unsigned short CommentLength
-)
+    )
 {
     int Err = NO_ERROR;
     int CommentPadLength = 4 - (CommentLength % 4 == 0 ? 4 : CommentLength % 4);
@@ -200,7 +200,7 @@ PcapNgWriteEnhancedPacket(
     long TimeStampLow,
     char* Comment,
     unsigned short CommentLength
-)
+    )
 {
     int Err = NO_ERROR;
     struct PCAPNG_BLOCK_HEAD Head;

--- a/src/pcapng.h
+++ b/src/pcapng.h
@@ -27,43 +27,44 @@ https://github.com/pcapng/pcapng
 
 #include <pshpack1.h>
 struct PCAPNG_BLOCK_HEAD {
-    long Type;
-    long Length;
+    DWORD Type;
+    DWORD Length;
 };
 struct PCAPNG_SECTION_HEADER_BODY {
-    long Magic; // endian detection (set this to PCAPNG_SECTION_HEADER_MAGIC)
-    short MajorVersion;
-    short MinorVersion;
-    long long Length;
+    DWORD Magic; // endian detection (set this to PCAPNG_SECTION_HEADER_MAGIC)
+    USHORT MajorVersion;
+    USHORT MinorVersion;
+    INT64 Length;
 };
 struct PCAPNG_INTERFACE_DESC_BODY {
-    short LinkType;
-    short Reserved;
-    long SnapLen;
+    USHORT LinkType;
+    USHORT Reserved;
+    DWORD SnapLen;
 };
 struct PCAPNG_ENHANCED_PACKET_BODY {
-    long InterfaceId;
-    long TimeStampHigh;
-    long TimeStampLow;
-    long CapturedLength; // excludes padding
-    long PacketLength; // excludes padding
-    char PacketData[0]; // padded to 4 bytes
+    DWORD InterfaceId;
+    DWORD TimeStampHigh;
+    DWORD TimeStampLow;
+    DWORD CapturedLength; // excludes padding
+    DWORD PacketLength;   // excludes padding
+    BYTE PacketData[0];   // padded to 4 bytes
 };
 struct PCAPNG_BLOCK_OPTION_ENDOFOPT {
-    short Code; // PCAPNG_OPTIONCODE_ENDOFOPT
-    short Length; // 0
+    USHORT Code;   // PCAPNG_OPTIONCODE_ENDOFOPT
+    USHORT Length; // 0
 };
 struct PCAPNG_BLOCK_OPTION_EPB_FLAGS {
-    short Code; // PCAPNG_OPTIONCODE_EPB_FLAGS
-    short Length; // 4
-    long Value;
+    USHORT Code;   // PCAPNG_OPTIONCODE_EPB_FLAGS
+    USHORT Length; // 4
+    DWORD Value;
 };
 struct PCAPNG_BLOCK_OPTION_COMMENT {
-    unsigned short Code; // PCAPNG_OPTIONCODE_COMMENT
-    unsigned short Length;
+    USHORT Code;         // PCAPNG_OPTIONCODE_COMMENT
+    USHORT Length;
+    CHAR   Comment[0];   // padded to 4 bytes
 };
 struct PCAPNG_BLOCK_TAIL {
-    long Length; // Same as PCAPNG_BLOCK_HEAD.Length, for easier backward processing.
+    DWORD Length; // Same as PCAPNG_BLOCK_HEAD.Length, for easier backward processing.
 };
 #include <poppack.h>
 
@@ -151,6 +152,44 @@ Done:
 }
 
 inline int
+PcapNgWriteCommentOption(
+    __in HANDLE File,
+    __in PCHAR CommentBuffer,
+    __in USHORT CommentLength
+)
+{
+    int Err = NO_ERROR;
+    int CommentPadLength = 4 - (CommentLength % 4 == 0 ? 4 : CommentLength % 4);
+    struct PCAPNG_BLOCK_OPTION_COMMENT Comment;
+    char Pad[4] = { 0 };
+
+    Comment.Code = PCAPNG_OPTIONCODE_COMMENT;
+    Comment.Length = CommentLength;
+
+    if (!WriteFile(File, &Comment, sizeof(Comment), NULL, NULL)) {
+        Err = GetLastError();
+        printf("WriteFile failed with %u\n", Err);
+        goto Done;
+    }
+    if (!WriteFile(File, CommentBuffer, CommentLength, NULL, NULL)) {
+        Err = GetLastError();
+        printf("WriteFile failed with %u\n", Err);
+        goto Done;
+    }
+    if (CommentPadLength > 0) {
+        if (!WriteFile(File, Pad, CommentPadLength, NULL, NULL)) {
+            Err = GetLastError();
+            printf("WriteFile failed with %u\n", Err);
+            goto Done;
+        }
+    }
+
+Done:
+
+    return Err;
+}
+
+inline int
 PcapNgWriteEnhancedPacket(
     HANDLE File,
     char* FragBuf,
@@ -159,39 +198,26 @@ PcapNgWriteEnhancedPacket(
     long IsSend,
     long TimeStampHigh, // usec (unless if_tsresol is used)
     long TimeStampLow,
-    unsigned long ProcessId
-    )
+    char* Comment,
+    USHORT CommentLength
+)
 {
     int Err = NO_ERROR;
     struct PCAPNG_BLOCK_HEAD Head;
     struct PCAPNG_ENHANCED_PACKET_BODY Body;
     struct PCAPNG_BLOCK_OPTION_ENDOFOPT EndOption;
     struct PCAPNG_BLOCK_OPTION_EPB_FLAGS EpbFlagsOption;
-    struct PCAPNG_BLOCK_OPTION_COMMENT CommentOption;
     struct PCAPNG_BLOCK_TAIL Tail;
     char Pad[4] = {0};
-// COMMENT_MAX_SIZE must be multiple of 4
-#define COMMENT_MAX_SIZE 16
-    char Comment[COMMENT_MAX_SIZE];
-    size_t CommentLength = 0;
+    BOOLEAN commentprovided = (CommentLength > 0 && Comment != NULL);
     int FragPadLength = (4 - ((sizeof(Body) + FragLength) & 3)) & 3; // pad to 4 bytes per the spec.
-    int TotalLength;
-
-    memset(Comment, 0, COMMENT_MAX_SIZE);
-    if SUCCEEDED(StringCchPrintfA(Comment, COMMENT_MAX_SIZE, "PID=%d", ProcessId)) {
-        if FAILED(StringCchLengthA(Comment, COMMENT_MAX_SIZE, &CommentLength)) {
-            CommentLength = 0;
-        }
-    } else {
-        memset(Comment, 0, COMMENT_MAX_SIZE);
-    }
-    CommentOption.Code = PCAPNG_OPTIONCODE_COMMENT;
-    CommentOption.Length = (unsigned short) CommentLength;
-    if (CommentOption.Length % 4 != 0)
-        CommentOption.Length += (4 - CommentOption.Length % 4);
-    TotalLength =
+    int TotalLength =
         sizeof(Head) + sizeof(Body) + FragLength + FragPadLength +
-        sizeof(EpbFlagsOption) + sizeof(CommentOption) + CommentOption.Length + sizeof(EndOption) + sizeof(Tail);
+        sizeof(EpbFlagsOption) + sizeof(EndOption) + sizeof(Tail) +
+        (commentprovided ?
+            sizeof(struct PCAPNG_BLOCK_OPTION_COMMENT) + sizeof(EndOption) + CommentLength +
+            (4 - (CommentLength % 4 == 0 ? 4 : CommentLength % 4)) //Comment Padding
+            : 0);
 
     Head.Type = PCAPNG_BLOCKTYPE_ENHANCED_PACKET;
     Head.Length = TotalLength;
@@ -233,15 +259,18 @@ PcapNgWriteEnhancedPacket(
         goto Done;
     }
 
-    if (!WriteFile(File, &CommentOption, sizeof(CommentOption), NULL, NULL)) {
-        Err = GetLastError();
-        printf("WriteFile failed with %u\n", Err);
-        goto Done;
-    }
-    if (!WriteFile(File, &Comment, CommentOption.Length, NULL, NULL)) {
-        Err = GetLastError();
-        printf("WriteFile failed with %u\n", Err);
-        goto Done;
+    if (commentprovided)
+    {
+        Err = PcapNgWriteCommentOption(
+            File,
+            Comment,
+            CommentLength
+        );
+        if (Err != NO_ERROR)
+        {
+            printf("WriteFile failed with %u\n", Err);
+            goto Done;
+        }
     }
 
     EndOption.Code = PCAPNG_OPTIONCODE_ENDOFOPT;

--- a/src/pcapng.h
+++ b/src/pcapng.h
@@ -27,51 +27,51 @@ https://github.com/pcapng/pcapng
 
 #include <pshpack1.h>
 struct PCAPNG_BLOCK_HEAD {
-    DWORD Type;
-    DWORD Length;
+    unsigned long Type;
+    unsigned long Length;
 };
 struct PCAPNG_SECTION_HEADER_BODY {
-    DWORD Magic; // endian detection (set this to PCAPNG_SECTION_HEADER_MAGIC)
-    USHORT MajorVersion;
-    USHORT MinorVersion;
-    INT64 Length;
+    unsigned long  Magic; // endian detection (set this to PCAPNG_SECTION_HEADER_MAGIC)
+    unsigned short MajorVersion;
+    unsigned short MinorVersion;
+    long long      Length;
 };
 struct PCAPNG_INTERFACE_DESC_BODY {
-    USHORT LinkType;
-    USHORT Reserved;
-    DWORD SnapLen;
+    unsigned short LinkType;
+    unsigned short Reserved;
+    unsigned long  SnapLen;
 };
 struct PCAPNG_ENHANCED_PACKET_BODY {
-    DWORD InterfaceId;
-    DWORD TimeStampHigh;
-    DWORD TimeStampLow;
-    DWORD CapturedLength; // excludes padding
-    DWORD PacketLength;   // excludes padding
-    BYTE PacketData[0];   // padded to 4 bytes
+    unsigned long InterfaceId;
+    unsigned long TimeStampHigh;
+    unsigned long TimeStampLow;
+    unsigned long CapturedLength; // excludes padding
+    unsigned long PacketLength;   // excludes padding
+    unsigned char PacketData[0];  // padded to 4 bytes
 };
 struct PCAPNG_BLOCK_OPTION_ENDOFOPT {
-    USHORT Code;   // PCAPNG_OPTIONCODE_ENDOFOPT
-    USHORT Length; // 0
+    unsigned short Code;          // PCAPNG_OPTIONCODE_ENDOFOPT
+    unsigned short Length;        // 0
 };
 struct PCAPNG_BLOCK_OPTION_EPB_FLAGS {
-    USHORT Code;   // PCAPNG_OPTIONCODE_EPB_FLAGS
-    USHORT Length; // 4
-    DWORD Value;
+    unsigned short Code;          // PCAPNG_OPTIONCODE_EPB_FLAGS
+    unsigned short Length;        // 4
+    unsigned long  Value;
 };
 struct PCAPNG_BLOCK_OPTION_COMMENT {
-    USHORT Code;         // PCAPNG_OPTIONCODE_COMMENT
-    USHORT Length;
-    CHAR   Comment[0];   // padded to 4 bytes
+    unsigned short Code;          // PCAPNG_OPTIONCODE_COMMENT
+    unsigned short Length;
+    char           Comment[0];    // padded to 4 bytes
 };
 struct PCAPNG_BLOCK_TAIL {
-    DWORD Length; // Same as PCAPNG_BLOCK_HEAD.Length, for easier backward processing.
+    unsigned long Length;         // Same as PCAPNG_BLOCK_HEAD.Length, for easier backward processing.
 };
 #include <poppack.h>
 
 inline int
 PcapNgWriteSectionHeader(
     HANDLE File
-    )
+)
 {
     int Err = NO_ERROR;
     struct PCAPNG_BLOCK_HEAD Head;
@@ -114,7 +114,7 @@ PcapNgWriteInterfaceDesc(
     HANDLE File,
     short LinkType,
     long SnapLen
-    )
+)
 {
     int Err = NO_ERROR;
     struct PCAPNG_BLOCK_HEAD Head;
@@ -155,7 +155,7 @@ inline int
 PcapNgWriteCommentOption(
     __in HANDLE File,
     __in PCHAR CommentBuffer,
-    __in USHORT CommentLength
+    __in unsigned short CommentLength
 )
 {
     int Err = NO_ERROR;
@@ -199,7 +199,7 @@ PcapNgWriteEnhancedPacket(
     long TimeStampHigh, // usec (unless if_tsresol is used)
     long TimeStampLow,
     char* Comment,
-    USHORT CommentLength
+    unsigned short CommentLength
 )
 {
     int Err = NO_ERROR;
@@ -259,15 +259,12 @@ PcapNgWriteEnhancedPacket(
         goto Done;
     }
 
-    if (commentprovided)
-    {
+    if (commentprovided) {
         Err = PcapNgWriteCommentOption(
             File,
             Comment,
-            CommentLength
-        );
-        if (Err != NO_ERROR)
-        {
+            CommentLength);
+        if (Err != NO_ERROR) {
             printf("WriteFile failed with %u\n", Err);
             goto Done;
         }


### PR DESCRIPTION
- Adding support for NDIS Metadata blocks as comments in pcapng
- Adjusting support for comments on EPB blocks to support above (Merging with recent PRs)
- Clearing privacy bit being set by some 802.11 adapters
- Correcting some comments, error messages, and variable types for consistency

Tested changes on two types of wlan adapters (nwifi & wdi) and on ethernet with two interfaces against wireshark version 3.2.0 for viewing pcapng files.