### PR TITLE
Automatically infer original fragment length for truncated fragments (Raw/Ethernet)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ msbuild -t:rebuild -p:configuration=release -p:platform=x64
 
 # History
 
+1.4.0 - Automatically infer original fragment length if captured fragments were truncated.
+
 1.3.0 - Add a comment to each packet containing the process id (PID).
 
 1.2.0 - Write direction info of each packet (epb_flags)

--- a/src/etl2pcapng.vcxproj
+++ b/src/etl2pcapng.vcxproj
@@ -102,7 +102,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>tdh.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>tdh.lib;ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -119,7 +119,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>tdh.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>tdh.lib;ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -140,7 +140,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>tdh.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>tdh.lib;ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -161,7 +161,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>tdh.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>tdh.lib;ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/src/main.c
+++ b/src/main.c
@@ -454,7 +454,7 @@ void WINAPI EventCallback(PEVENT_RECORD ev)
             OutFile,
             AuxFragBuf,
             TotalFragmentLength,
-            // For LSO packets, ignore inferred original fragment length.
+            // For LSO v2 packets, inferred original fragment length is ignored since length field in IP header is not filled.
             InferredOriginalFragmentLength <= TotalFragmentLength ? TotalFragmentLength : InferredOriginalFragmentLength,
             Iface->PcapNgIfIndex,
             !!(ev->EventHeader.EventDescriptor.Keyword & KW_SEND),

--- a/src/main.c
+++ b/src/main.c
@@ -12,11 +12,11 @@ in Windows that produces packet capture events) to pcapng format
 Issues:
 
 -ndiscap supports packet truncation and so does pcapng, but ndiscap doesn't
- currently log metadata about truncation in its events (other than marking
- them with a keyword), so we try to infer the original fragment length from
- IP headers and it currently works for RAW and Eithernet frames. For LSO v2
- packets since length field is not filled, we can't infer the original length
- for them and we use the truncated length as their original length.
+ currently log metadata about truncation in its events, so we try to infer
+ the original fragment length from IP headers and it currently works for
+ RAW and Eithernet frames. For LSO v2 packets since length field is not
+ filled, we can't infer the original length for them and we use the
+ truncated length as their original length.
 
 */
 

--- a/src/main.c
+++ b/src/main.c
@@ -270,7 +270,7 @@ void WINAPI EventCallback(PEVENT_RECORD ev)
     ULARGE_INTEGER TimeStamp;
     short Type;
     unsigned long TotalFragmentLength;
-    unsigned long InferedOriginalFragmentLength;
+    unsigned long InferredOriginalFragmentLength;
 
     if (!IsEqualGUID(&ev->EventHeader.ProviderId, &NdisCapId) ||
         (ev->EventHeader.EventDescriptor.Id != tidPacketFragment &&
@@ -448,13 +448,14 @@ void WINAPI EventCallback(PEVENT_RECORD ev)
         TotalFragmentLength = AuxFragBufOffset + FragLength;
 
         // Parse the to see if it's truncated. If so, try to recover the original length.
-        InferedOriginalFragmentLength = InferOriginalFragmentLength(AuxFragBuf, TotalFragmentLength, Type);
+        InferredOriginalFragmentLength = InferOriginalFragmentLength(AuxFragBuf, TotalFragmentLength, Type);
 
         PcapNgWriteEnhancedPacket(
             OutFile,
             AuxFragBuf,
             TotalFragmentLength,
-            InferedOriginalFragmentLength == 0 ? TotalFragmentLength : InferedOriginalFragmentLength,
+            // For LSO packets, ignore inferred original fragment length.
+            InferredOriginalFragmentLength <= TotalFragmentLength ? TotalFragmentLength : InferredOriginalFragmentLength,
             Iface->PcapNgIfIndex,
             !!(ev->EventHeader.EventDescriptor.Keyword & KW_SEND),
             TimeStamp.HighPart,

--- a/src/main.c
+++ b/src/main.c
@@ -16,7 +16,7 @@ Issues:
  them with a keyword), so we try to infer the original fragment length from
  IP headers and it currently works for RAW and Eithernet frames. For LSO v2
  packets since length field is not filled, we can't infer the original length
- for them.
+ for them and we use the truncated length as their original length.
 
 */
 

--- a/src/pcapng.h
+++ b/src/pcapng.h
@@ -231,7 +231,7 @@ PcapNgWriteEnhancedPacket(
     Body.InterfaceId = InterfaceId;
     Body.TimeStampHigh = TimeStampHigh;
     Body.TimeStampLow = TimeStampLow;
-    Body.PacketLength = OrigFragLength; // actual length
+    Body.PacketLength = OrigFragLength; // original length
     Body.CapturedLength = FragLength; // truncated length
     if (!WriteFile(File, &Body, sizeof(Body), NULL, NULL)) {
         Err = GetLastError();

--- a/src/pcapng.h
+++ b/src/pcapng.h
@@ -194,6 +194,7 @@ PcapNgWriteEnhancedPacket(
     HANDLE File,
     char* FragBuf,
     unsigned long FragLength,
+    unsigned long OrigFragLength,
     long InterfaceId,
     long IsSend,
     long TimeStampHigh, // usec (unless if_tsresol is used)
@@ -230,7 +231,7 @@ PcapNgWriteEnhancedPacket(
     Body.InterfaceId = InterfaceId;
     Body.TimeStampHigh = TimeStampHigh;
     Body.TimeStampLow = TimeStampLow;
-    Body.PacketLength = FragLength; // actual length
+    Body.PacketLength = OrigFragLength; // actual length
     Body.CapturedLength = FragLength; // truncated length
     if (!WriteFile(File, &Body, sizeof(Body), NULL, NULL)) {
         Err = GetLastError();


### PR DESCRIPTION
Currently, if packets were captured using packettruncatebytes=\<size\>, wireshark's TCP analysis will be confused when parsing these truncated packets and you will see lots of bogus "[TCP Previous segment not captured]" and "[TCP ACKed unseen segment]".

With this PR, etl2pcapng will parse Ethernet and IP headers and infer the original length of packets and assign the length to PCAPNG_ENHANCED_PACKET_BODY::PacketLength. Note that doing so will not increase the converted file size.

Limitations:
1. Does not work with LSO v2 packets since length is not filled in IPv4/6 headers.

Demo:
Left - before this PR
Right - after this PR
![image](https://user-images.githubusercontent.com/6022514/92191023-78689600-ee17-11ea-8857-5493413b880d.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/etl2pcapng/27)
<!-- Reviewable:end -->
