### PR TITLE
Fix TotalLength calculation bug that leads to corrupt blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ msbuild -t:rebuild -p:configuration=release -p:platform=x64
 
 # History
 
+1.4.1 - Fix a bug leading to writing corrupt packets.
+
 1.4.0 - Automatically infer original fragment length if captured fragments were truncated.
 
 1.3.0 - Add a comment to each packet containing the process id (PID).

--- a/src/main.c
+++ b/src/main.c
@@ -452,7 +452,7 @@ void WINAPI EventCallback(PEVENT_RECORD ev)
             TimeStamp.LowPart,
             CommentLength > 0 ? (char*)&Comment : NULL,
             (unsigned short)CommentLength);
-        
+
         AuxFragBufOffset = 0;
         NumFramesConverted++;
     } else {
@@ -471,7 +471,7 @@ int __cdecl wmain(int argc, wchar_t** argv)
     if (argc == 2 &&
         (!wcscmp(argv[1], L"-v") ||
          !wcscmp(argv[1], L"--version"))) {
-        printf("etl2pcapng version 1.4.0\n");
+        printf("etl2pcapng version 1.4.1\n");
         return 0;
     }
 


### PR DESCRIPTION
https://github.com/microsoft/etl2pcapng/commit/870232e9dbff6e053df350e0018009cd5a28d1ee introduced a bug where TotalLength in PcapNgWriteEnhancedPacket is incorrectly calculated which leads to corrupt blocks in pcap. Specifically, sizeof(option end) is added twice to TotalLength.