### PR TITLE
Enable Control Flow Guard (CFG) for released binaries

### DIFF
--- a/src/etl2pcapng.vcxproj
+++ b/src/etl2pcapng.vcxproj
@@ -137,6 +137,7 @@
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>.</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -159,6 +160,7 @@
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>.</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/src/main.c
+++ b/src/main.c
@@ -495,7 +495,7 @@ int __cdecl wmain(int argc, wchar_t** argv)
     if (argc == 2 &&
         (!wcscmp(argv[1], L"-v") ||
          !wcscmp(argv[1], L"--version"))) {
-        printf("etl2pcapng version 1.5.0\n");
+        printf("etl2pcapng version 1.6.0\n");
         return 0;
     }
 


### PR DESCRIPTION
We are using etl2pcapng.exe (currently the latest released version - 1.5.0) in a .NET Core project which we run daily code analysis on via an Azure build pipeline. One of the pipeline jobs involves running BinSkim on our files as part of security validation. The issue I am trying to fix with this PR is that we have been getting the following error in the BinSkim job:

<Project_path>\etl2pcapng.exe: error BA2008: 'etl2pcapng.exe' does not enable the control flow guard (CFG) mitigation. To resolve this issue, pass /guard:cf on both the compiler and linker command lines. Binaries also require the /DYNAMICBASE linker option in order to enable CFG.

/DYNAMICBASE is enabled by default, unlike /guard:cf, so I had to explicitly enable CFG. We were hoping that, if this PR goes through, you could produce a new official build with the CFG build flag enabled in order to resolve the error above. 