### PR TITLE
Refactor VMNic Interface property retrieval

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -334,3 +334,9 @@ ASALocalRun/
 # Cmake build folder
 src/build/
 src/build_releases/
+
+# VS Code settings folder
+.vscode
+
+# CMake folder
+build/

--- a/src/main.c
+++ b/src/main.c
@@ -754,17 +754,22 @@ void AddInterface(PEVENT_RECORD ev, unsigned long LowerIfIndex, unsigned long Mi
             NewIface->VMNic.SourceNicName = propertyData;
         }
         propertyData = 0;
+        propertyDataLength = 0;
 
         // SourcePortName
-        GetPropertyFromEventRecord(ev, L"SourcePortName", ULONG_MAX, &propertyDataLength, &propertyData);
-        NewIface->VMNic.SourcePortName = propertyData;
+        if(!GetPropertyFromEventRecord(ev, L"SourcePortName", ULONG_MAX, &propertyDataLength, &propertyData)) {
+            NewIface->VMNic.SourcePortName = propertyData;
+        }
         propertyData = 0;
+        propertyDataLength = 0;
 
         // SourceNicType
-        GetPropertyFromEventRecord(ev, L"SourceNicType", ULONG_MAX, &propertyDataLength, &propertyData);
-        NewIface->VMNic.SourceNicType = propertyData;
+        if(!GetPropertyFromEventRecord(ev, L"SourceNicType", ULONG_MAX, &propertyDataLength, &propertyData)) {
+            NewIface->VMNic.SourceNicType = propertyData;
+        }
         propertyData = 0;
-
+        propertyDataLength = 0;
+        
         NewIface->VMNic.SourcePortId = VMSwitchPacketFragment.SourcePortId;
         NewIface->VlanId = VMSwitchPacketFragment.VlanId;
     }


### PR DESCRIPTION
This commit refactors the property retrieval code in AddInterface into a separate function. It rewrites the memory allocations and copies to ensure that memory bounds are properly addressed, to prevent any buffer overflows or off-by-one errors. The removed code was being flagged by a static analyzer.

I tested the original (main branch) and modified binaries with an ETL sample I captured on an arm64 Win11 VM. The resulting pcapng files hashed the same.

Tagging @maolson-msft for any feedback on PR, thanks in advance.