### PR TITLE
WriteFile to fail is that you are passing NULL as the fourth parameter, which is not allowed for older Windows vision.

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -60,7 +60,8 @@ BOOLEAN BufferBytes(HANDLE File, void* Buf, unsigned long BufSize)
 
     if (BufSize > CurSpace && CurSpace < WRITEBUF_SIZE) {
         // Flush write buffer to make space for the new bytes.
-        if (!WriteFile(File, WriteBuf, WriteBufNext, NULL, NULL)) {
+        DWORD at;
+        if (!WriteFile(File, WriteBuf, WriteBufNext, &at, NULL)) {
             return FALSE;
         }
         WriteBufNext = 0;
@@ -70,7 +71,8 @@ BOOLEAN BufferBytes(HANDLE File, void* Buf, unsigned long BufSize)
     if (BufSize > CurSpace) {
         // The buffer is empty and we still don't have enough space.
         // Bypass the buffer and write directly to the file.
-        if (!WriteFile(File, Buf, BufSize, NULL, NULL)) {
+        DWORD at;
+        if (!WriteFile(File, Buf, BufSize, &at, NULL)) {
             return FALSE;
         }
     } else {
@@ -83,7 +85,8 @@ BOOLEAN BufferBytes(HANDLE File, void* Buf, unsigned long BufSize)
 
 BOOLEAN FlushBufferBytes(HANDLE File)
 {
-    if (!WriteFile(File, WriteBuf, WriteBufNext, NULL, NULL)) {
+    DWORD at;
+    if (!WriteFile(File, WriteBuf, WriteBufNext, &at, NULL)) {
         return FALSE;
     }
     WriteBufNext = 0;


### PR DESCRIPTION
Please check the [link](https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-writefile?redirectedfrom=MSDN).

4th parameter (lpNumberOfBytesWritten) is expecting pointer to DWORD value when you pass NULL to that parameter it attempts to write DWORD to null pointer which causes exception.

To fix this problem, you need to declare a DWORD variable and pass its address as the fourth parameter, like this:

 DWORD at;
 iWriteFile(File, WriteBuf, WriteBufNext, &at, NULL)

This way, you can also check the value of 'at' after the function returns to see if it matches the expected number of bytes.

